### PR TITLE
natural torch installation not nvidia binaries

### DIFF
--- a/cuda7.0-cudnn4/Dockerfile
+++ b/cuda7.0-cudnn4/Dockerfile
@@ -14,35 +14,60 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -yq --n
     bison \
     cmake \
     flex \
+    git-core \
+    gnuplot \
+    gnuplot-x11 \
     g++ \
+    imagemagick \
     libboost-all-dev \
     libdouble-conversion-dev \
     libedit-dev \
     libevent-dev \
+    libfftw3-dev \
     libgflags-dev \
     libgoogle-glog-dev \
+    libgraphicsmagick1-dev \
     libiberty-dev \
     libjemalloc-dev \
+    libjpeg-dev \
     libkrb5-dev \
     liblz4-dev \
     liblzma-dev \
     libmatio-dev \
     libnuma-dev \
+    libpng-dev \
     libprotobuf-dev \
+    libqt4-core \
+    libqt4-gui \
+    libqt4-dev \
+    libreadline-dev \ 
     libsasl2-dev \
+    libsdl2-dev \
     libsnappy-dev \
+    libsox-dev \
+    libsox-fmt-all \
     libssl-dev \
     libtool \
+    libzmq3-dev \
+    ncurses-dev \
     pkg-config \
     protobuf-compiler \
     python-zmq \
-    torch7-nv \
+    sox \
+    # torch7-nv \
     unzip \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# install torch
+RUN git clone https://github.com/torch/distro.git usr/local/torch --recursive \
+&& git config --global url.https://github.com/.insteadOf git://github.com/ \
+&& cd usr/local/torch && ./install.sh
+
+ENV PATH /usr/local/torch/install/bin:$PATH
+
 # workaround
-RUN ln -s /usr/lib/x86_64-linux-gnu/libTH* /usr/lib/
+# RUN ln -s /usr/lib/x86_64-linux-gnu/libTH* /usr/lib/
 
 RUN git clone https://github.com/facebook/iTorch.git ~/itorch \
   && cd ~/itorch \

--- a/ubuntu-14.04/Dockerfile
+++ b/ubuntu-14.04/Dockerfile
@@ -14,35 +14,60 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -yq --n
     bison \
     cmake \
     flex \
+    git-core \
+    gnuplot \
+    gnuplot-x11 \
     g++ \
+    imagemagick \
     libboost-all-dev \
     libdouble-conversion-dev \
     libedit-dev \
     libevent-dev \
+    libfftw3-dev \
     libgflags-dev \
     libgoogle-glog-dev \
+    libgraphicsmagick1-dev \
     libiberty-dev \
     libjemalloc-dev \
+    libjpeg-dev \
     libkrb5-dev \
     liblz4-dev \
     liblzma-dev \
     libmatio-dev \
     libnuma-dev \
+    libpng-dev \
     libprotobuf-dev \
+    libqt4-core \
+    libqt4-gui \
+    libqt4-dev \
+    libreadline-dev \ 
     libsasl2-dev \
+    libsdl2-dev \
     libsnappy-dev \
+    libsox-dev \
+    libsox-fmt-all \
     libssl-dev \
     libtool \
+    libzmq3-dev \
+    ncurses-dev \
     pkg-config \
     protobuf-compiler \
     python-zmq \
-    torch7-nv \
+    sox \
+    # torch7-nv \
     unzip \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# install torch
+RUN git clone https://github.com/torch/distro.git usr/local/torch --recursive \
+&& git config --global url.https://github.com/.insteadOf git://github.com/ \
+&& cd usr/local/torch && ./install.sh
+
+ENV PATH /usr/local/torch/install/bin:$PATH
+
 # workaround
-RUN ln -s /usr/lib/x86_64-linux-gnu/libTH* /usr/lib/
+# RUN ln -s /usr/lib/x86_64-linux-gnu/libTH* /usr/lib/
 
 RUN git clone https://github.com/facebook/iTorch.git ~/itorch \
   && cd ~/itorch \


### PR DESCRIPTION
The Nvidia binaries are not up to date. We therefore should use the normal way of installing torch.
